### PR TITLE
calendar patch

### DIFF
--- a/drupal/modules/views/plugins/calendar_plugin_row_civicrm.inc
+++ b/drupal/modules/views/plugins/calendar_plugin_row_civicrm.inc
@@ -190,8 +190,18 @@ class calendar_plugin_row_civicrm extends calendar_plugin_row {
       }
       elseif (!$is_field && !empty($item)) {
         $item_start_date = new dateObject($item, $db_tz);
-        $item_end_date   = $item_start_date;
-        $node->date_id   = array('calendar.' . $node->id . '.' . $field_name . '.0');
+        $node->date_id = array('calendar.' . $node->id . '.' . $field_name . '.0');
+        // KG - if we have a civicrm_activity_duration let's use it!
+        // Calculate the end_date so that the calendar item can have the correct height in the week and day displays.
+        // NOTE: imported views can have a bug that causes $view->style_options['groupby_times'] not to be set.
+        // Solution (for each display/page): go into the View -> Calendar -> Settings: Time Grouping -> save;
+        if (isset($row->civicrm_activity_duration)) {
+          $duration = $row->civicrm_activity_duration;
+          $item_value2 = date("Y-m-d H:i:s", strtotime($item. '+' . $duration . 'minutes'));
+          $item_end_date = new dateObject($item_value2, $db_tz);
+        } else {
+          $item_end_date = $item_start_date;
+        }
       }
 
       // If we don't have date value, go no further.


### PR DESCRIPTION
**Before:** a CiviCRM calendar item only has a start_date so Calendar module only renders enough yellow block to ensure the text is encapsulated.

![image](https://user-images.githubusercontent.com/5340555/77853636-45541380-71a2-11ea-9dec-6ca7ed60f062.png)

**After:** now constructing an end_date based on activity duration -> if it exists use it. We now have a properly sized yellow block:

![image](https://user-images.githubusercontent.com/5340555/77853676-a5e35080-71a2-11ea-9312-04bfb3efe1e0.png)
